### PR TITLE
Bugfix/user role null

### DIFF
--- a/app/scripts/app/users/UsersDirective.js
+++ b/app/scripts/app/users/UsersDirective.js
@@ -16,23 +16,19 @@ angular.module('UsersModule')  // Directive adds user roles the User Form
             scope.user.id = $stateParams.id;
             api.getUser($stateParams.id).success(function (user) {
               scope.user = user;
+              if (typeof user.roles === 'object')
+                scope.role = user.roles[0].replace('ROLE_', '');
+              if (typeof user.roles === 'string')
+                scope.role = user.roles.replace('ROLE_', '');
             });
-          }
-          function role_is(role, isRole) {
-            if (isRole) {
-              scope.role = role.replace('ROLE_', '');
-            }
-            return isRole;
           }
           scope.role_is = function (role) {
             if (typeof scope.user.roles === 'undefined')
               return null;
-            if (typeof scope.user.roles === 'object') {
-              return role_is(role, scope.user.roles.indexOf(role) > -1);
-            }
-            if (typeof scope.user.roles === 'string') {
-              return role_is(role, scope.user.roles === role);
-            }
+            if (typeof scope.user.roles === 'object')
+              return scope.user.roles.indexOf(role) > -1;
+            if (typeof scope.user.roles === 'string')
+              return scope.user.roles === role;
           };
           // Callback on submit
           scope.submit = function () {

--- a/app/scripts/app/users/UsersDirective.js
+++ b/app/scripts/app/users/UsersDirective.js
@@ -16,16 +16,23 @@ angular.module('UsersModule')  // Directive adds user roles the User Form
             scope.user.id = $stateParams.id;
             api.getUser($stateParams.id).success(function (user) {
               scope.user = user;
-              scope.role = user.roles;
             });
+          }
+          function role_is(role, isRole) {
+            if (isRole) {
+              scope.role = role;
+            }
+            return isRole;
           }
           scope.role_is = function (role) {
             if (typeof scope.user.roles === 'undefined')
               return null;
-            if (typeof scope.user.roles === 'object')
-              return scope.user.roles.indexOf(role) > -1;
-            if (typeof scope.user.roles === 'string')
-              return scope.user.roles === role;
+            if (typeof scope.user.roles === 'object') {
+              return role_is(role, scope.user.roles.indexOf(role) > -1);
+            }
+            if (typeof scope.user.roles === 'string') {
+              return role_is(role, scope.user.roles === role);
+            }
           };
           // Callback on submit
           scope.submit = function () {

--- a/app/scripts/app/users/UsersDirective.js
+++ b/app/scripts/app/users/UsersDirective.js
@@ -2,47 +2,48 @@
 
 /* Directives */
 angular.module('UsersModule')  // Directive adds user roles the User Form
-.directive('userForm', [
-  'usersService',
-  '$stateParams',
-  '$window',
-  function (api, $stateParams, $window) {
-    return {
-      link: function (scope) {
-        scope.user = {};
-        // Override the user object on the scope in edit user form
-        if ($stateParams.id !== undefined) {
-          // This is true for Updating User Info
-          scope.user.id = $stateParams.id;
-          api.getUser($stateParams.id).success(function (user) {
-            scope.user = user;
-          });
+  .directive('userForm', [
+    'usersService',
+    '$stateParams',
+    '$window',
+    function (api, $stateParams, $window) {
+      return {
+        link: function (scope) {
+          scope.user = {};
+          // Override the user object on the scope in edit user form
+          if ($stateParams.id !== undefined) {
+            // This is true for Updating User Info
+            scope.user.id = $stateParams.id;
+            api.getUser($stateParams.id).success(function (user) {
+              scope.user = user;
+              scope.role = user.roles;
+            });
+          }
+          scope.role_is = function (role) {
+            if (typeof scope.user.roles === 'undefined')
+              return null;
+            if (typeof scope.user.roles === 'object')
+              return scope.user.roles.indexOf(role) > -1;
+            if (typeof scope.user.roles === 'string')
+              return scope.user.roles === role;
+          };
+          // Callback on submit
+          scope.submit = function () {
+            scope.user.roles = [scope.role];
+            if (!scope.user.id)
+              return api.addUser(scope.user);
+            else
+              return api.updateUser(scope.user);
+          };
+          scope.delete = function (user) {
+            if (!$window.confirm('Are you sure you want to delete this account?'))
+              return;
+            return api.deleteUser(user, function () {
+              // redirect to the previous page
+              return $window.history.back();
+            });
+          };
         }
-        scope.role_is = function (role) {
-          if (typeof scope.user.roles === 'undefined')
-            return null;
-          if (typeof scope.user.roles === 'object')
-            return scope.user.roles.indexOf(role) > -1;
-          if (typeof scope.user.roles === 'string')
-            return scope.user.roles === role;
-        };
-        // Callback on submit
-        scope.submit = function () {
-          scope.user.roles = [scope.role];
-          if (!scope.user.id)
-            return api.addUser(scope.user);
-          else
-            return api.updateUser(scope.user);
-        };
-        scope.delete = function (user) {
-          if (!$window.confirm('Are you sure you want to delete this account?'))
-            return;
-          return api.deleteUser(user, function () {
-            // redirect to the previous page
-            return $window.history.back();
-          });
-        };
-      }
-    };
-  }
-]);
+      };
+    }
+  ]);

--- a/app/scripts/app/users/UsersDirective.js
+++ b/app/scripts/app/users/UsersDirective.js
@@ -20,7 +20,7 @@ angular.module('UsersModule')  // Directive adds user roles the User Form
           }
           function role_is(role, isRole) {
             if (isRole) {
-              scope.role = role;
+              scope.role = role.replace('ROLE_', '');
             }
             return isRole;
           }


### PR DESCRIPTION
Save for the formatting, the only line that changed is the addition of line 19.

The bug:
When the `userEdit` page loads, the value `scope.role` is not set. This meant that unless the user actively selected a role, this value will remain undefined /null. This situation led to cases where for example, if a user's password/username is changed and the editor did not select any role before submitting the form, then the user's role would get set to null.