### PR TITLE
Allow multiple meanings for the same etymology part

### DIFF
--- a/app/scripts/app/names/NamesController.js
+++ b/app/scripts/app/names/NamesController.js
@@ -81,6 +81,13 @@ angular.module('NamesModule').controller('NamesAddEntriesCtrl', [
     };
 
     $scope.generate_glossary = function () {
+      var regenerate = confirm("Do you want to automatically generate gloss from this morphology value?"+
+        "\nSelect Cancel/No to leave as is.");
+
+      if (!regenerate){
+        return;
+      }
+
       if (!$scope.name.morphology) {
         $scope.name.etymology = [];
         return;
@@ -114,6 +121,8 @@ angular.module('NamesModule').controller('NamesAddEntriesCtrl', [
       } else {
         $scope.name.etymology = updateEtymology(etymologyParts, partMeaningDict, etymology);
       }
+      
+      toastr.warning("Please, re-check gloss before saving/publishing as some parts might have been removed/changed.");
     };
 
     $scope.publish = function () {

--- a/app/scripts/app/names/NamesDirective.js
+++ b/app/scripts/app/names/NamesDirective.js
@@ -46,7 +46,8 @@ angular.module('NamesModule')  // Directive adds the geolocation autocompletes o
           scope.add_etymology = function () {
             return scope.name.etymology.push({
               part: '',
-              meaning: ''
+              meaning: '',
+              isFresh: true
             });
           };
 

--- a/app/tmpls/names/directives/etymology.html
+++ b/app/tmpls/names/directives/etymology.html
@@ -1,7 +1,7 @@
 <div class="row etymology" ng-repeat="etymology in name.etymology track by $index">
     <div class="col-sm-4">
         <label>Part</label>
-        <input type="text" disabled class="form-control" name="part[{{$index}}]" ng-model="etymology.part" required>
+        <input type="text" ng-disabled="!etymology.isFresh" class="form-control" name="part[{{$index}}]" ng-model="etymology.part" required>
         <span ng-show="form.part[{{$index}}].$invalid && !form.part[{{$index}}].$pristine"
             class="help-block text-danger">This etymology part is required</span>
     </div>


### PR DESCRIPTION
**ISSUE DETAILS:**
Look at this name Odùẹ̀ṣọ́. It has two distinct meanings that can’t fit in one box. But the current design isn’t allowing me to put a second definition of Ẹ̀ṣọ́

The box that says “part” should be editable so I can put a new segment in there and define it.
![Multiple meanings for the same etymology part](https://github.com/user-attachments/assets/36e93908-48aa-475b-bb47-fc5763942de0)